### PR TITLE
move packges to @envato npm account

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "foundation-design-system-tokens",
+  "name": "@envato/foundation-design-system-tokens",
   "version": "0.1.0",
   "description": "foundation design system tokens",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "gulp"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "token"
-  ],
+  "files": ["dist"],
+  "keywords": ["token"],
   "author": "Envato Market Foundation Team",
   "license": "MIT",
   "devDependencies": {

--- a/packages/breakpoints/package.json
+++ b/packages/breakpoints/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "foundation-design-system-tokens-breakpoints",
+  "name": "@envato/foundation-design-system-tokens-breakpoints",
   "version": "0.1.0",
   "description": "foundation design system tokens breakpoints",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "gulp"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "breakpoints"
-  ],
+  "files": ["dist"],
+  "keywords": ["breakpoints"],
   "author": "Envato Market Foundation Team",
   "license": "MIT",
   "devDependencies": {

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "foundation-design-system-tokens-colors",
+  "name": "@envato/foundation-design-system-tokens-colors",
   "version": "0.1.0",
   "description": "foundation design system tokens colors",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "gulp"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "colors"
-  ],
+  "files": ["dist"],
+  "keywords": ["colors"],
   "author": "Envato Market Foundation Team",
   "license": "MIT",
   "devDependencies": {

--- a/packages/glyphs/package.json
+++ b/packages/glyphs/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "foundation-design-system-tokens-glyphs",
+  "name": "@envato/foundation-design-system-tokens-glyphs",
   "version": "0.1.0",
   "description": "foundation design system tokens glyphs",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "gulp"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "glyphs"
-  ],
+  "files": ["dist"],
+  "keywords": ["glyphs"],
   "author": "Envato Market Foundation Team",
   "license": "MIT",
   "devDependencies": {

--- a/packages/spacing/package.json
+++ b/packages/spacing/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "foundation-design-system-tokens-spacing",
+  "name": "@envato/foundation-design-system-tokens-spacing",
   "version": "0.1.0",
   "description": "foundation design system tokens spacing",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "gulp"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "spacing"
-  ],
+  "files": ["dist"],
+  "keywords": ["spacing"],
   "author": "Envato Market Foundation Team",
   "license": "MIT",
   "devDependencies": {

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,17 +1,13 @@
 {
-  "name": "foundation-design-system-tokens-typography",
+  "name": "@envato/foundation-design-system-tokens-typography",
   "version": "0.1.0",
   "description": "foundation design system tokens typography",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "gulp"
   },
-  "files": [
-    "dist"
-  ],
-  "keywords": [
-    "typography"
-  ],
+  "files": ["dist"],
+  "keywords": ["typography"],
   "author": "Envato Market Foundation Team",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Currently we have both [`envato-foundation`](https://www.npmjs.com/~envato-foundation) and [`envato`](https://www.npmjs.com/~envato) npm account. 

* The `envato` one is a paid account which can use private npm package
* `envato-foundation` is the one was originally only mean to used for foundation

When working on the `market-shared-header` component, I realise it's a bit of pain to switch from one account to another, and it also feel not consistent as we have packages within Envato npm but with different prefix.

* Migrate all design system tokens to the shared `@envato` account. 

```
# before
npm i foundation-design-system-tokens

# after
npm i @envato/foundation-design-system-tokens
```

* Update `main` field from `index.js` to `dist/index.js` so we don't need to pass `dist` when use the JavaScript version of tokens.

```JavaScript
// before
import Tokens from 'foundation-design-system-tokens/dist'

// after
import Tokens from '@envato/foundation-design-system-tokens'
```

Since npm does not allow unpublish package anymore after the `leftpad` accident, I'll simply publish the package to the `@envato` npm account instead of contacting npm support.

cc @jordanlewiz @pawelgalazka @Shervanator @thefoxis 

